### PR TITLE
add the first hosts to the prod inventory

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -957,7 +957,8 @@ class SpeedtestResults(object):
         self.client = client or {}
 
         self._share = None
-        self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        # self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
+        self.timestamp = '%sZ' % datetime.datetime.now(datetime.timezone.utc).isoformat()
         self.bytes_received = 0
         self.bytes_sent = 0
 


### PR DESCRIPTION
After getting the error that something will be in the future be the datetime module, 
`
./speedtest.py 
Retrieving speedtest.net configuration...
/home/cb0n3y/admin/git/speedtest-cli/./speedtest.py:960: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()`

i've have fix the thing for me changing this: 

`self.timestamp = '%sZ' % datetime.datetime.utcnow().isoformat()
`

for this: 
`self.timestamp = '%sZ' % datetime.datetime.now(datetime.timezone.utc).isoformat()`
